### PR TITLE
Fix drifting tooltip box on an inline element

### DIFF
--- a/book/lexicon.css
+++ b/book/lexicon.css
@@ -16,6 +16,7 @@
     z-index: 1000000;
     font-size: 14px;
     font-weight: normal;
+    top: 0;
 }
 
 .hint:hover:before {


### PR DESCRIPTION
This happens when an inline element is wrapped into multiple lines. This pull request adds `top: 0` to `.hint:hover:after` in order to make sure that `:after` starts at the same position as `:before`.

Ref: https://github.com/g0v/vtaiwan.tw/issues/14

**Before**

![image](https://cloud.githubusercontent.com/assets/1153134/5723027/e4440746-9b7b-11e4-88dd-cc917b9c661a.png)

**After**

![image](https://cloud.githubusercontent.com/assets/1153134/5723022/da756f84-9b7b-11e4-8018-33b2a989a189.png)
